### PR TITLE
Regexp#match? doesn't exist in ruby 2.3

### DIFF
--- a/lib/jekyll_ext/converter.rb
+++ b/lib/jekyll_ext/converter.rb
@@ -13,7 +13,7 @@ module Jekyll
     end
 
     def matches(ext)
-      /md|markdown/.match?(ext)
+      /md|markdown/.match(ext)
     end
 
     def output_ext(ext)

--- a/lib/jekyll_ext/generator.rb
+++ b/lib/jekyll_ext/generator.rb
@@ -17,7 +17,7 @@ module Jekyll
 
     def remove_stale_lily_image_references(site)
       site.static_files.reject! do |static_file|
-        /lily_images\/.*\.(svg|png)/.match?(static_file.path)
+        /lily_images\/.*\.(svg|png)/.match(static_file.path)
       end
     end
   end


### PR DESCRIPTION
Ubuntu 16.04LTE comes with ruby 2.3 which does not implement Regexp#match

got the error message
jekyll 3.7.2 | Error:  undefined method `match?' for /lily_images\/.*\.(svg|png)/:Regexp

I don't know enough ruby to know if this change is OK, but it seems to work.